### PR TITLE
Optimise APT Statements

### DIFF
--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:18.04
 MAINTAINER RightMesh AG, https://github.com/RightMesh
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y software-properties-common
-RUN apt-get install -y build-essential git
-RUN apt-get install -y openjdk-8-jre openjdk-8-jdk
-
+RUN apt-get update && apt-get upgrade -y \
+ && apt-get install -y software-properties-common \
+  build-essential git \
+  openjdk-8-jre openjdk-8-jdk

--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
-MAINTAINER RightMesh AG, https://github.com/RightMesh
+
+MAINTAINER Left Technologies Inc.
+
 RUN apt-get update && apt-get upgrade -y \
  && apt-get install -y software-properties-common \
   build-essential git \

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
-MAINTAINER RightMesh AG, https://github.com/RightMesh
+
+MAINTAINER Left Technologies Inc.
+
 RUN apt-get update && apt-get upgrade -y \
  && apt-get install -y software-properties-common \
   build-essential git \

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:16.04
 MAINTAINER RightMesh AG, https://github.com/RightMesh
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y software-properties-common
-RUN apt-get install -y build-essential git
-RUN apt-get install -y openjdk-8-jre openjdk-8-jdk
-
+RUN apt-get update && apt-get upgrade -y \
+ && apt-get install -y software-properties-common \
+  build-essential git \
+  openjdk-8-jre openjdk-8-jdk


### PR DESCRIPTION
Previously we had four `RUN` lines, each invoking different apt commands. The result is that this small image had six cached layers, which we needed to pull down for both this image and those that extend it.

This PR collapses those all down to one RUN command.

I also updated the maintainer line with the new corporation name.